### PR TITLE
Use "this" instead of "global" for fallback if "window" undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ Webpack2Polyfill.prototype.apply = function(compiler){
         comments("Webpack2 Polyfill"),
         "(function(){",
         this.indent(snippets),
-        "}).call(typeof window != \"undefined\" ? window : this);",
+        "}).call(typeof window != \"undefined\" ? window : self);",
         comments("Webpack2 Polyfill end")
       ]));
 

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ Webpack2Polyfill.prototype.apply = function(compiler){
         "if(typeof window != \"undefined\") return window;",
         "if(typeof global != \"undefined\") return global;",
         "if(typeof self != \"undefined\") return self;",
-        "})()",
+        "})())",
         comments("Webpack2 Polyfill end")
       ]));
 

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ Webpack2Polyfill.prototype.apply = function(compiler){
         comments("Webpack2 Polyfill"),
         "(function(){",
         this.indent(snippets),
-        "}).call(typeof window != \"undefined\" ? window : global);",
+        "}).call(typeof window != \"undefined\" ? window : this);",
         comments("Webpack2 Polyfill end")
       ]));
 

--- a/index.js
+++ b/index.js
@@ -67,7 +67,11 @@ Webpack2Polyfill.prototype.apply = function(compiler){
         comments("Webpack2 Polyfill"),
         "(function(){",
         this.indent(snippets),
-        "}).call(typeof window != \"undefined\" ? window : self);",
+        "}).call((function(){",
+        "if(typeof window != \"undefined\") return window;",
+        "if(typeof global != \"undefined\") return global;",
+        "if(typeof self != \"undefined\") return self;",
+        "})()",
         comments("Webpack2 Polyfill end")
       ]));
 


### PR DESCRIPTION
## Issue

Fixes #1 

On webworker environment, "window" is undefined therefore it will use "global". But, it will result in error as "global" also never defined.

## Proposed

Using "this" as it's always exist as the base global variable.